### PR TITLE
run all abckend tests

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,19 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    DATABASE_URL: str = ""
+    DO_SPACES_KEY: str = ""
+    DO_SPACES_SECRET: str = ""
+    DO_SPACES_REGION: str = ""
+    DO_SPACES_BUCKET: str = ""
+    GRADIENT_API_KEY: str = ""
+    OPENAI_API_KEY: str = ""
+    GRADIENT_KB_ID: str = ""
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+
+settings = Settings()

--- a/agent/db.py
+++ b/agent/db.py
@@ -1,0 +1,44 @@
+"""
+Async SQLAlchemy engine, session factory, and DB helpers for the CommunitAI agent.
+DATABASE_URL must be an async-compatible URL, e.g. postgresql+asyncpg://...
+"""
+
+from sqlalchemy import Column, String, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from agent.config import settings
+
+
+engine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
+
+SessionLocal = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False,
+    autocommit=False,
+)
+
+
+class Base(DeclarativeBase):
+    """Shared declarative base for agent ORM models."""
+    pass
+
+
+class Meeting(Base):
+    """Minimal ORM model for updating meeting status from the agent."""
+    __tablename__ = "meetings"
+
+    id = Column(String, primary_key=True)
+    status = Column(String, nullable=False)
+
+
+async def update_meeting_status(meeting_id: str, status: str) -> None:
+    """Update the status field of a meeting row by its ID."""
+    async with SessionLocal() as session:
+        await session.execute(
+            text("UPDATE meetings SET status = :status WHERE id = :id"),
+            {"status": status, "id": meeting_id},
+        )
+        await session.commit()


### PR DESCRIPTION
This pull request introduces foundational configuration and database support for the CommunitAI agent. The main changes include adding a settings management system using Pydantic, and establishing an asynchronous SQLAlchemy setup with a minimal ORM model and helper function for meeting status updates.

Configuration management:

* Added a `Settings` class in `agent/config.py` using `pydantic_settings.BaseSettings` to manage environment variables, including database and API keys, with `.env` file support.

Database setup and helpers:

* Introduced `agent/db.py` with an async SQLAlchemy engine and session factory, using the `DATABASE_URL` from settings.
* Defined a shared declarative base `Base` for ORM models and a minimal `Meeting` model for tracking meeting status.
* Added an `update_meeting_status` async helper function to update the status of a meeting by its ID.